### PR TITLE
add account/logout route to delete auth tokens to be regenerated when logged into again

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.urls import path
-from .views import login, register, sample_api
+from .views import login, register, logout, sample_api
 
 urlpatterns = [
   path('login', login),
   path('register', register),
-  path('sample-api', sample_api)
+  path('logout', logout),
+  path('sample-api', sample_api),
 ]

--- a/account/views.py
+++ b/account/views.py
@@ -42,7 +42,7 @@ def register(request):
   if username is None or password is None or email is None:
     return Response({'error': 'Please provided username, password, and email'},
       status=HTTP_400_BAD_REQUEST)
-  
+
   # If account with name already exists, return 409 - Conflict
   if User.objects.filter(username=username).exists():
     return Response({'error': 'An account with that name already exists'},
@@ -57,12 +57,30 @@ def register(request):
   if user is None:
     return Response({'error': 'An unexpected error has ocurred while registering account. Try again.'},
       status=HTTP_500_INTERNAL_SERVER_ERROR)
-  
+
   # Get user token and return it
   token, _ = Token.objects.get_or_create(user=user)
   return Response({'token': token.key},
     status=HTTP_200_OK)
 
+@csrf_exempt
+@api_view(['POST'])
+@permission_classes((AllowAny,))
+def logout(request):
+  """
+  Logout of user account
+  """
+  # Get token to delete
+  token = request.data.get('token')
+
+  # Delete token
+
+  try:
+    instance = Token.objects.get(key=token)
+    instance.delete()
+    return Response(status=HTTP_200_OK)
+  except:
+    return Response(status=HTTP_400_BAD_REQUEST)
 
 @csrf_exempt
 @api_view(['GET'])


### PR DESCRIPTION
## Changes
- Add /account/logout

## Routes
### POST /account/logout token=<authentication_token>
Removes the authentication token from database effectively logging the user out. They are then required to generate a new token by logging in again.
Reponse:
- 200 OK : Token removed successfully
- 400 Bad Request: Token was unable to be removed